### PR TITLE
Fixed check for timeout to include status code 500

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -329,9 +329,11 @@ func (this *FcmResponseStatus) PrintResults() {
 // IsTimeout check whether the response timeout based on http response status
 // code and if any error is retryable
 func (this *FcmResponseStatus) IsTimeout() bool {
-	if this.StatusCode > 500 {
+	if this.StatusCode >= 500 {
 		return true
-	} else if this.StatusCode == 200 {
+	}
+
+	if this.StatusCode == 200 {
 		for _, val := range this.Results {
 			for k, v := range val {
 				if k == error_key && retreyableErrors[v] == true {


### PR DESCRIPTION
IsTimeout should return true when HTTP status code is 500
[https://firebase.google.com/docs/cloud-messaging/http-server-ref](url)