### PR TITLE
Fix int overflow by changing MulticastId and MsgId in FcmResponseStat…

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -61,12 +61,12 @@ type FcmMsg struct {
 type FcmResponseStatus struct {
 	Ok            bool
 	StatusCode    int
-	MulticastId   int                 `json:"multicast_id"`
+	MulticastId   int64               `json:"multicast_id"`
 	Success       int                 `json:"success"`
 	Fail          int                 `json:"failure"`
 	Canonical_ids int                 `json:"canonical_ids"`
 	Results       []map[string]string `json:"results,omitempty"`
-	MsgId         int                 `json:"message_id,omitempty"`
+	MsgId         int64               `json:"message_id,omitempty"`
 	Err           string              `json:"error,omitempty"`
 	RetryAfter    string
 }


### PR DESCRIPTION
Firebase Message and Multicast IDs are now bigger than `int` can handle. Using `int64` for `MulticastId` and `MsgId` in `FcmResponseStat` resolves that issue.

Original error messages:

`"message_id":4808105333029652615}2017/01/19 09:08:08 json: cannot unmarshal number 4808105333029652615 into Go value of type int`

`{"multicast_id":5417432682003747856,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"0:1484813306392284%7031b2e6f9fd7ecd"}]}2017/01/19 09:08:26 json: cannot unmarshal number 5417432682003747856 into Go value of type int`
