### PR TITLE
Allow callers to inject their own HTTP client.

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -39,6 +39,7 @@ var (
 type FcmClient struct {
 	ApiKey  string
 	Message FcmMsg
+	client  *http.Client
 }
 
 // FcmMsg represents fcm request message
@@ -90,8 +91,13 @@ type NotificationPayload struct {
 
 // NewFcmClient init and create fcm client
 func NewFcmClient(apiKey string) *FcmClient {
+	return NewFcmClientWithHttp(apiKey, &http.Client{})
+}
+
+func NewFcmClientWithHttp(apiKey string, client *http.Client) *FcmClient {
 	fcmc := new(FcmClient)
 	fcmc.ApiKey = apiKey
+	fcmc.client = client
 
 	return fcmc
 }
@@ -166,8 +172,7 @@ func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
 	request.Header.Set("Authorization", this.apiKeyHeader())
 	request.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	response, err := client.Do(request)
+	response, err := this.client.Do(request)
 
 	if err != nil {
 		return fcmRespStatus, err


### PR DESCRIPTION
This is necessary for AppEngine usage, where the standard HTTP client from net/http is not allowed.