### PR TITLE
Add NewFcmRegIdsNotification and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,21 +101,19 @@ its recommended to use a backoff time to retry the request - (if RetryAfter
 ### Send to A topic
 
 ```go
-
 package main
 
 import (
 	"fmt"
-    "github.com/NaySoftware/go-fcm"
+	"github.com/NaySoftware/go-fcm"
 )
 
 const (
-	 serverKey = "YOUR-KEY"
-     topic = "/topics/someTopic"
+	serverKey = "YOUR-KEY"
+	topic = "/topics/someTopic"
 )
 
 func main() {
-
 	data := map[string]string{
 		"msg": "Hello World1",
 		"sum": "Happy Day",
@@ -124,70 +122,99 @@ func main() {
 	c := fcm.NewFcmClient(serverKey)
 	c.NewFcmMsgTo(topic, data)
 
-
 	status, err := c.Send()
 
-
 	if err == nil {
-    status.PrintResults()
+		status.PrintResults()
 	} else {
 		fmt.Println(err)
 	}
-
 }
-
-
 ```
 
-
-### Send to a list of Devices (tokens)
+### Send data message to a list of Devices (tokens)
 
 ```go
-
 package main
 
 import (
 	"fmt"
-    "github.com/NaySoftware/go-fcm"
+	"github.com/NaySoftware/go-fcm"
 )
 
 const (
-	 serverKey = "YOUR-KEY"
+	serverKey = "YOUR-KEY"
 )
 
 func main() {
-
 	data := map[string]string{
 		"msg": "Hello World1",
 		"sum": "Happy Day",
 	}
 
-  ids := []string{
-      "token1",
-  }
+	ids := []string{
+		"token1",
+	}
 
-
-  xds := []string{
-      "token5",
-      "token6",
-      "token7",
-  }
+	xds := []string{
+		"token5",
+		"token6",
+		"token7",
+	}
 
 	c := fcm.NewFcmClient(serverKey)
-    c.NewFcmRegIdsMsg(ids, data)
-    c.AppendDevices(xds)
+	c.NewFcmRegIdsMsg(ids, data)
+	c.AppendDevices(xds)
 
 	status, err := c.Send()
 
-
 	if err == nil {
-    status.PrintResults()
+		status.PrintResults()
 	} else {
 		fmt.Println(err)
 	}
-
 }
+```
 
+### Send notification message to a list of Devices (tokens)
 
+```go
+package main
 
+import (
+	"fmt"
+	"github.com/NaySoftware/go-fcm"
+)
+
+const (
+	serverKey = "YOUR-KEY"
+)
+
+func main() {
+	notificationPayload := &fcm.NotificationPayload{
+		Body: "Hello World",
+	}
+
+	ids := []string{
+		"token1",
+	}
+
+	xds := []string{
+		"token5",
+		"token6",
+		"token7",
+	}
+
+	c := fcm.NewFcmClient(serverKey)
+	c.NewFcmRegIdsNotification(ids, notificationPayload)
+	c.AppendDevices(xds)
+
+	status, err := c.Send()
+
+	if err == nil {
+		status.PrintResults()
+	} else {
+		fmt.Println(err)
+	}
+}
 ```

--- a/fcm.go
+++ b/fcm.go
@@ -130,6 +130,14 @@ func (this *FcmClient) NewFcmRegIdsMsg(list []string, body interface{}) *FcmClie
 
 }
 
+// New FcmRegIdsNotification gets a list of devices with notification payload
+func (this *FcmClient) NewFcmRegIdsNotification(list []string, payload *NotificationPayload) *FcmClient {
+	this.newDevicesList(list)
+	this.SetNotificationPayload(payload)
+
+	return this
+}
+
 // newDevicesList init the devices list
 func (this *FcmClient) newDevicesList(list []string) *FcmClient {
 	this.Message.RegistrationIds = make([]string, len(list))


### PR DESCRIPTION
https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages

In FCM, there are two types of message, notification message and data message.

There is a support for data message in this library, but when I want to send notification message, I have to use NewFcmRegIdsMsg (to register tokens) and SetNotificationPayload (to register notification message).
I think this approach is redundant, so I suggest adding NewFcmRegIdsNotification that can register tokens and notification message at once.

Please check my request.
Thank you.
  