### PR TITLE
Add `SendWithContext` to send an FCM request with a context.

### DIFF
--- a/fcm.go
+++ b/fcm.go
@@ -2,6 +2,7 @@ package fcm
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -154,8 +155,7 @@ func (this *FcmClient) apiKeyHeader() string {
 }
 
 // sendOnce send a single request to fcm
-func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
-
+func (this *FcmClient) sendOnce(ctx context.Context) (*FcmResponseStatus, error) {
 	fcmRespStatus := new(FcmResponseStatus)
 
 	jsonByte, err := this.Message.toJsonByte()
@@ -166,6 +166,10 @@ func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
 	request, err := http.NewRequest("POST", fcmServerUrl, bytes.NewBuffer(jsonByte))
 	request.Header.Set("Authorization", this.apiKeyHeader())
 	request.Header.Set("Content-Type", "application/json")
+
+	if ctx != nil {
+		request = request.WithContext(ctx)
+	}
 
 	client := &http.Client{}
 	response, err := client.Do(request)
@@ -199,8 +203,13 @@ func (this *FcmClient) sendOnce() (*FcmResponseStatus, error) {
 
 // Send to fcm
 func (this *FcmClient) Send() (*FcmResponseStatus, error) {
-	return this.sendOnce()
+	return this.sendOnce(nil)
 
+}
+
+// SendWithContext sends the request to FCM with a context
+func (this *FcmClient) SendWithContext(ctx context.Context) (*FcmResponseStatus, error) {
+	return this.sendOnce(ctx)
 }
 
 // toJsonByte converts FcmMsg to a json byte


### PR DESCRIPTION
This allows deadlines and cancellation.